### PR TITLE
Update kit name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ What this document will help you accomplish:
 Prerequisites:
 --------------
 
-- Download the `Terracotta DB 10.2 kit` from http://www.terracotta.org/downloads/ and unzip it / untar it.
+- Download the `Standalone installation package for Terracotta DB` from http://www.terracotta.org/downloads/ and unzip it / untar it.
 
 - Have a Terracotta DB license file ready (you can get a trial license file from : http://www.terracotta.org/downloads/ )
 


### PR DESCRIPTION
On terracotta.org the kit is referred to as: Standalone installation package for Terracotta DB.